### PR TITLE
getty: use high res image for 'thumbnail'

### DIFF
--- a/mediachain/translation/getty/translator.py
+++ b/mediachain/translation/getty/translator.py
@@ -40,7 +40,7 @@ class Getty(Translator):
 
         try:
             thumb_uri = [i['uri'] for i in parsed_metadata['display_sizes']
-                         if i['name'] == 'thumb'].pop()
+                         if i['name'] == 'comp'].pop()
             data['thumbnail'] = {
                 '__mediachain_asset__': True,
                 'uri': thumb_uri
@@ -69,4 +69,3 @@ class Getty(Translator):
     def can_translate_file(file_path):
         ext = os.path.splitext(file_path)[-1]
         return ext.lower() == '.json'
-


### PR DESCRIPTION
This is a temporary change that sends the high resolution `comp` image uri in the `thumbnail` asset, instead of the small non-watermarked `thumb` image.  This will let the indexer serve higher resolution images to the frontend.

Temporary, because the longer term solution is to stop treating `thumbnail` as a special field, and handle all images with the newer binary asset output format in https://github.com/mediachain/mediachain-client/pull/68
